### PR TITLE
Make sure that kotlin dependency is propagated to library consumer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     ext.kotlin_version = '1.2.21'
     ext.dokka_version = '0.9.15'
-	ext.versionCode = 3
-	ext.versionName = '0.0.3'
+	ext.versionCode = 4
+	ext.versionName = '0.0.4'
     repositories {
 		jcenter()
 		google()

--- a/finger/build.gradle
+++ b/finger/build.gradle
@@ -25,8 +25,7 @@ android {
 dependencies {
 	implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support:appcompat-v7:27.0.2'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-	testImplementation 'junit:junit:4.12'
+    api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
 ext {


### PR DESCRIPTION
When not declaring the kotlin dependency as transitive dependency the consumer app will throw an ClassNotFound error