### PR TITLE
Upgraded androidX.biometric to stable and simplified API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This fingerprint library aims to make the use of fingerprint authentication in y
 
 First, include _finger_ in your project by adding
   ````groovy
-  // minimum Version for this readme is 1.0.0-rc1
+  // minimum Version for this readme is 1.0.0
 implementation "de.adorsys.android:finger:${latestFingerVersion}"
 ````
 
@@ -19,7 +19,7 @@ implementation "de.adorsys.android:finger:${latestFingerVersion}"
 You can use _finger_ as follows:
 
 ```` kotlin 
-val finger = Finger(applicationContext)
+val finger = Finger(context) // will internally always use application context
 finger.subscribe(object : FingerListener {
                   override fun onFingerprintAuthenticationSuccess() {
                       // The user authenticated successfully -> go on with your logic
@@ -32,18 +32,13 @@ finger.subscribe(object : FingerListener {
               })
               
 finger.showDialog(
-            // instance of FragmentActivity
-            this,
-            Triple(
-                // title
-                getString(R.string.text_fingerprint),  
-                // subtitle    
-                null,         
-                // description                             
-                null                                       
-            ),
-            // default parameter is android.R.cancel
-            "login with password"                          
+            activity = this,
+            strings = DialogStrings(
+                title = getString(R.string.text_fingerprint),  
+                subtitle = "" // defaults to null if nothing is assigned    
+                description = "" // defaults to null if nothing is assigned
+                cancelButtonText = "login with password" // default parameter is android.R.cancel 
+            )                         
         )
 ````
 
@@ -61,35 +56,32 @@ override fun onPause() {
 ````
 
 ##  error handling
-_finger_ provides its own error messages which are considered as fallback but they already contain more information as the standard system messages. Concerning the error handling _finger_ gives you the whole power to control what messages the user should receive for every error case. You can assign Finger a map of errors as follows:
+_finger_ usually emits the standard system error messages. But you can also assign _finger_ a map of errors for each error type:
  
 ```` kotlin
-// use import androidx.biometric.BiometricPrompt; --> is provided by the library
 val errors = mapOf(
-                Pair(BiometricPrompt.ERROR_HW_UNAVAILABLE, getString(R.string.error_override_hw_unavailable)),
-                Pair(BiometricPrompt.ERROR_UNABLE_TO_PROCESS, getString(R.string.error_override_unable_to_process)),
-                Pair(BiometricPrompt.ERROR_TIMEOUT, getString(R.string.error_override_error_timeout)),
-                Pair(BiometricPrompt.ERROR_NO_SPACE, getString(R.string.error_override_no_space)),
-                Pair(BiometricPrompt.ERROR_CANCELED, getString(R.string.error_override_canceled)),
-                Pair(BiometricPrompt.ERROR_LOCKOUT, getString(R.string.error_override_lockout)),
-                Pair(BiometricPrompt.ERROR_VENDOR, getString(R.string.error_override_vendor)),
-                Pair(BiometricPrompt.ERROR_LOCKOUT_PERMANENT, getString(R.string.error_override_lockout_permanent)),
-                Pair(BiometricPrompt.ERROR_USER_CANCELED, getString(R.string.error_override_user_cancel)),
-                Pair(Finger.FINGERPRINT_ERROR_NOT_RECOGNIZED, getString(R.string.error_override_not_recognized)))
+	Pair(FingerprintManager.FINGERPRINT_ERROR_HW_UNAVAILABLE, getString(R.string.error_override_hw_unavailable)),
+    Pair(FingerprintManager.FINGERPRINT_ERROR_UNABLE_TO_PROCESS, getString(R.string.error_override_unable_to_process)),
+    Pair(FingerprintManager.FINGERPRINT_ERROR_TIMEOUT, getString(R.string.error_override_error_timeout)),
+    Pair(FingerprintManager.FINGERPRINT_ERROR_NO_SPACE, getString(R.string.error_override_no_space)),
+    Pair(FingerprintManager.FINGERPRINT_ERROR_CANCELED, getString(R.string.error_override_canceled)),
+    Pair(FingerprintManager.FINGERPRINT_ERROR_LOCKOUT, getString(R.string.error_override_lockout)),
+    Pair(FingerprintManager.FINGERPRINT_ERROR_VENDOR, getString(R.string.error_override_vendor)),
+    Pair(FingerprintManager.FINGERPRINT_ERROR_LOCKOUT_PERMANENT, getString(R.string.error_override_lockout_permanent)),
+    Pair(FingerprintManager.FINGERPRINT_ERROR_USER_CANCELED, getString(R.string.error_override_user_cancel)),
+    Pair(Finger.ERROR_NOT_RECOGNIZED, getString(R.string.error_override_not_recognized)))
 val finger = Finger(applicationContext, errors)
 ````
 
 Usually, errors is defined as an emptyMap() as default argument.
    
-You can also force the library to use the system's human readable error messages
-
 ```` kotlin
-val finger = Finger(applicationContext, useSystemErrors = true)
+val finger = Finger(context = this)
 ````
 or
 
 ```` kotlin
-val finger = Finger(applicationContext, errors, true)
+val finger = Finger(context = this, errors = errors)
 ````
 The latter uses only the system error messages if no own error message can be found in the map. So you can very well customize when to show which message.
 
@@ -97,7 +89,6 @@ The latter uses only the system error messages if no own error message can be fo
 
 ### Proguard
 -keep class de.adorsys.android.finger.**
-
 -dontwarn de.adorsys.android.finger.**
 
 ### Contributors

--- a/app/src/main/java/de/adorsys/android/fingersample/MainActivity.kt
+++ b/app/src/main/java/de/adorsys/android/fingersample/MainActivity.kt
@@ -1,6 +1,9 @@
 package de.adorsys.android.fingersample
 
+import android.annotation.SuppressLint
 import android.graphics.drawable.Drawable
+import android.hardware.biometrics.BiometricPrompt
+import android.hardware.fingerprint.FingerprintManager
 import android.os.Bundle
 import android.widget.Button
 import android.widget.ImageView
@@ -18,10 +21,11 @@ class MainActivity : AppCompatActivity(), FingerListener {
     private var iconFingerprintError: Drawable? = null
 
 
+    @SuppressLint("InlinedApi")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        finger = Finger(applicationContext)
+        finger = Finger(this)
     }
 
     override fun onResume() {
@@ -56,14 +60,7 @@ class MainActivity : AppCompatActivity(), FingerListener {
     private fun showDialog() {
         finger.showDialog(
             this,
-            Triple(
-                // title
-                getString(R.string.text_fingerprint),
-                // subtitle
-                null,
-                // description
-                null
-            )
+            Finger.DialogStrings(title = getString(R.string.text_fingerprint))
         )
     }
 

--- a/app/src/main/java/de/adorsys/android/fingersample/MainActivityJava.java
+++ b/app/src/main/java/de/adorsys/android/fingersample/MainActivityJava.java
@@ -32,7 +32,7 @@ public class MainActivityJava extends AppCompatActivity implements FingerListene
         iconFingerprintError = ResourcesCompat.getDrawable(getResources(), R.drawable.ic_fingerprint_off, getTheme());
 
         // You can also assign a map of error strings for the errors defined in the lib as second parameter
-        finger = new Finger(getApplicationContext());
+        finger = new Finger(this);
     }
 
     @Override
@@ -83,13 +83,8 @@ public class MainActivityJava extends AppCompatActivity implements FingerListene
     private void showDialog() {
         finger.showDialog(
                 this,
-                new Triple<String, String, String>(
-                        // title
-                        getString(R.string.text_fingerprint),
-                        // subtitle
-                        null,
-                        // description
-                        null
+                new Finger.DialogStrings(
+                        getString(R.string.text_fingerprint)
                 )
         );
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.3.61'
     ext.dokka_version = '0.9.15'
-    ext.versionCode = 11
-    ext.versionName = '1.0.0-rc1'
+    ext.versionCode = 12
+    ext.versionName = '1.0.0-rc2'
     repositories {
         jcenter()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }

--- a/finger/build.gradle
+++ b/finger/build.gradle
@@ -28,7 +28,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    api 'androidx.biometric:biometric:1.0.0-rc01'
+    implementation 'androidx.biometric:biometric:1.0.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }
 

--- a/finger/src/main/res/values/strings.xml
+++ b/finger/src/main/res/values/strings.xml
@@ -1,13 +1,3 @@
 <resources>
-    <string name="fingerprint_error_hardware_unavailable">No fingerprint hardware detected.</string>
-    <string name="fingerprint_error_unable_to_process">Please try again and check if the fingerprint is activated in your phone\'s settings.</string>
-    <string name="fingerprint_error_timeout">Operation timed out. Try again.</string>
-    <string name="fingerprint_error_canceled">Operation cancelled.</string>
-    <string name="fingerprint_error_lockout">Too many attempts. Try again in 30 seconds or more.</string>
-    <string name="fingerprint_error_not_recognized">The fingerprint was not recognized. Please try again later.</string>
     <string name="fingerprint_error_unknown">Unknown error. Please try again later.</string>
-    <string name="fingerprint_error_no_space">The fingerprint validation operation could not be finished because your device\'s storage is full.</string>
-    <string name="fingerprint_error_lockout_permanent">The fingerprint operation caused your device to be locked too many times.
-		You will have to lock your device and unlock it with your alternative unlocking method.</string>
-    <string name="fingerprint_error_user_cancelled">You have cancelled the fingerprint operation.</string>
 </resources>


### PR DESCRIPTION
- Library does not have its own error messages any more as it overcomplicated the api usage. User can now choose between system errors or own
- ShowDialog now takes an object for all the dialog strings --> DialogStrings instead of Triple to make api more readable --> named parameters
- Updated Readme
- Updated gradle