### PR TITLE
Exchanged FingerprintManagerCompat with BiometricManager

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     ext.kotlin_version = '1.3.61'
     ext.dokka_version = '0.9.15'
-    ext.versionCode = 15
-    ext.versionName = '1.0.0'
+    ext.versionCode = 16
+    ext.versionName = '1.0.1'
 
     repositories {
         jcenter()

--- a/finger/src/main/java/de/adorsys/android/finger/Finger.kt
+++ b/finger/src/main/java/de/adorsys/android/finger/Finger.kt
@@ -1,6 +1,5 @@
 package de.adorsys.android.finger
 
-import android.annotation.SuppressLint
 import android.annotation.TargetApi
 import android.content.Context
 import android.os.Build
@@ -49,7 +48,6 @@ class Finger @JvmOverloads constructor(context: Context, private val errors: Map
      * Check if the device has suitable hardware for fingerprint authentication
      * and if the device has setup fingerprints to check on.
      */
-    @SuppressLint("MissingPermission")
     @TargetApi(Build.VERSION_CODES.M)
     fun hasFingerprintEnrolled() = when (biometricManager?.canAuthenticate()) {
         BIOMETRIC_SUCCESS -> true
@@ -60,7 +58,6 @@ class Finger @JvmOverloads constructor(context: Context, private val errors: Map
      * Subscribe for the fingerprint events by passing an {@link FingerListener}.
      * Best place to to this is onResume.
      */
-    @SuppressLint("MissingPermission")
     @TargetApi(Build.VERSION_CODES.M)
     fun subscribe(listener: FingerListener) {
         fingerListener = listener

--- a/finger/src/main/java/de/adorsys/android/finger/Finger.kt
+++ b/finger/src/main/java/de/adorsys/android/finger/Finger.kt
@@ -38,8 +38,12 @@ class Finger @JvmOverloads constructor(context: Context, private val errors: Map
 
     private val applicationContext = context.applicationContext
     private val handler = Handler()
-    private val biometricManager: BiometricManager? = BiometricManager.from(context)
     private var fingerListener: FingerListener? = null
+
+    // lazy initialization as maybe never assigned
+    private val biometricManager: BiometricManager? by lazy {
+        BiometricManager.from(context)
+    }
 
     /**
      * Check if the device has suitable hardware for fingerprint authentication


### PR DESCRIPTION
FingerprintManagerCompat is deprecated and androidX.biometric offers a replacement for the old api which is now used by the library. It already wraps the calls to FingerprintManagerCompat which were previously checked by Finger